### PR TITLE
TT-2012: Get the MSA running in the AWS environment

### DIFF
--- a/terraform/ec2-app.tf
+++ b/terraform/ec2-app.tf
@@ -1,8 +1,4 @@
-module "verify_connect_app" {
-  source = "terraform-aws-modules/ec2-instance/aws"
-
-  name = "verify_connect_app"
-
+resource "aws_instance" "verify_connect_app" {
   ami                         = "ami-3fc8d75b"
   instance_type               = "t2.small"
   key_name                    = "default"
@@ -14,9 +10,15 @@ module "verify_connect_app" {
   user_data                   = "${file("user-data.sh")}"
   source_dest_check           = false
 
+  root_block_device {
+    volume_size           = "50"
+    delete_on_termination = "true"
+  }
+
   tags = {
     Terraform   = "true"
     Environment = "dev"
     Application = "passport-verify-stub-relying-party"
+    Name        = "verify_connect_app"
   }
 }

--- a/terraform/ec2-bastion.tf
+++ b/terraform/ec2-bastion.tf
@@ -1,7 +1,4 @@
-module "verify_connect_bastion" {
-  source = "terraform-aws-modules/ec2-instance/aws"
-
-  name = "verify_connect_bastion"
+resource "aws_instance" "verify_connect_bastion" {
 
   ami                         = "ami-3fc8d75b"
   instance_type               = "t2.small"
@@ -13,9 +10,9 @@ module "verify_connect_bastion" {
   source_dest_check           = false
   associate_public_ip_address = true
   user_data                   = "${file("user-data.sh")}"
-
   tags = {
     Terraform   = "true"
     Environment = "dev"
+    Name = "verify_connect_bastion"
   }
 }

--- a/terraform/ec2-lms.tf
+++ b/terraform/ec2-lms.tf
@@ -1,8 +1,4 @@
-module "verify_connect_lms" {
-  source = "terraform-aws-modules/ec2-instance/aws"
-
-  name = "verify_connect_lms"
-
+resource "aws_instance" "verify_connect_lms" {
   ami                         = "ami-3fc8d75b"
   instance_type               = "t2.small"
   key_name                    = "default"
@@ -14,8 +10,14 @@ module "verify_connect_lms" {
   source_dest_check           = false
   user_data                   = "${file("user-data.sh")}"
 
+  root_block_device {
+    volume_size           = "50"
+    delete_on_termination = "true"
+  }
+
   tags = {
     Terraform   = "true"
     Environment = "dev"
+    Name        = "verify_connect_lms"
   }
 }

--- a/terraform/ec2-msa.tf
+++ b/terraform/ec2-msa.tf
@@ -10,13 +10,18 @@ resource "aws_instance" "verify_connect_msa" {
   source_dest_check           = false
   user_data                   = "${file("msa/msa-user-data.sh")}"
 
+  root_block_device {
+    volume_size           = "50"
+    delete_on_termination = "true"
+  }
+
   provisioner "file" {
     source      = "msa/verify-matching-service-adapter.conf"
     destination = "/home/ubuntu/verify-matching-service-adapter.conf"
 
     connection {
-      type     = "ssh"
-      user     = "ubuntu"
+      type         = "ssh"
+      user         = "ubuntu"
       bastion_host = "35.177.196.23"
       bastion_user = "ubuntu"
     }
@@ -27,8 +32,8 @@ resource "aws_instance" "verify_connect_msa" {
     destination = "/home/ubuntu/config.yml"
 
     connection {
-      type     = "ssh"
-      user     = "ubuntu"
+      type         = "ssh"
+      user         = "ubuntu"
       bastion_host = "35.177.196.23"
       bastion_user = "ubuntu"
     }
@@ -39,8 +44,8 @@ resource "aws_instance" "verify_connect_msa" {
     destination = "/home/ubuntu/msa.env"
 
     connection {
-      type     = "ssh"
-      user     = "ubuntu"
+      type         = "ssh"
+      user         = "ubuntu"
       bastion_host = "35.177.196.23"
       bastion_user = "ubuntu"
     }

--- a/terraform/ec2-vsp.tf
+++ b/terraform/ec2-vsp.tf
@@ -1,10 +1,6 @@
-module "verify_connect_vsp" {
-  source = "terraform-aws-modules/ec2-instance/aws"
-
-  name = "verify_connect_vsp"
-
+resource "aws_instance" "verify_connect_vsp" {
   ami                         = "ami-3fc8d75b"
-  instance_type               = "t2.micro"
+  instance_type               = "t2.small"
   key_name                    = "default"
   monitoring                  = false
   vpc_security_group_ids      = ["${module.verify_connect_sg.this_security_group_id}"]
@@ -14,8 +10,14 @@ module "verify_connect_vsp" {
   source_dest_check           = false
   user_data                   = "${file("user-data.sh")}"
 
+  root_block_device {
+    volume_size           = "50"
+    delete_on_termination = "true"
+  }
+
   tags = {
     Terraform   = "true"
     Environment = "dev"
+    Name        = "verify_connect_vsp"
   }
 }

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -1,18 +1,17 @@
-#module "verify-connect-db" {
-#  source     = "terraform-aws-modules/rds/aws"
-#  identifier = "verify-connect-db"
-#  engine             = "postgres"
-#  engine_version     = "9.6.3"
-#  instance_class     = "db.t2.micro"
-#  allocated_storage  = 20
-#  storage_encrypted  = false
-#  port               = "5432"
-#  username           = "${var.dbuser}"
-#  password           = "${var.dbpass}"
-#  maintenance_window = "Mon:00:00-Mon:03:00"
-#  backup_window      = "03:00-06:00"
-#
-#  subnet_ids = ["${module.vpc.private_subnets}"]
-#  family     = "postgres9.6"
-#}
+module "verify-connect-db" {
+  source     = "terraform-aws-modules/rds/aws"
+  identifier = "verify-connect-db"
+  engine             = "postgres"
+  engine_version     = "9.6.3"
+  instance_class     = "db.t2.small"
+  allocated_storage  = 50
+  storage_encrypted  = false
+  port               = "5432"
+  username           = "${var.dbuser}"
+  password           = "${var.dbpass}"
+  maintenance_window = "Mon:00:00-Mon:03:00"
+  backup_window      = "03:00-06:00"
 
+  subnet_ids = ["${module.vpc.private_subnets}"]
+  family     = "postgres9.6"
+}


### PR DESCRIPTION
Changed the EC2 provisioner from the terraform module to the standard
terraform resource

Modified the EC2 instance and disk sizes to match the HLD document

Co-authored-by: Richard Towers <richard.towers@digital.cabinet-office.gov.uk>